### PR TITLE
LogicSugar: 修复语句输入框无法点击聚焦（BoxSelect 误吞 TextField 事件）

### DIFF
--- a/src/logicsugar/assist/BoxSelect.java
+++ b/src/logicsugar/assist/BoxSelect.java
@@ -257,6 +257,17 @@ public class BoxSelect{
         return target instanceof Image;
     }
 
+    /** True when the click hits a text input or the expression editor (self or ancestor chain).
+     *  These must never be swallowed by the drag state machine, or they cannot take focus. */
+    private static boolean isClickOnEditable(Element target){
+        Element cur = target;
+        while(cur != null){
+            if(cur instanceof TextField || cur instanceof logicsugar.assist.expr.ExpressionEditor) return true;
+            cur = cur.parent;
+        }
+        return false;
+    }
+
     /** 判断元素是否是 canvas（LCanvas）的后代。
      *  返回按钮、变量按钮等在 LogicDialog.buttons 区，不在 canvas 内。
      *  只有 canvas 内的空白区才允许框选。 */
@@ -349,6 +360,13 @@ public class BoxSelect{
         // 兜底：hit test 可能因父容器裁剪/层叠等原因未命中按钮内部元素，
         // 手动检测点击位置是否落在任何 Button 的边界内（MindustryX 的 JUMP/pencil 按钮等）
         if(isClickWithinButtonBounds(target, stageCoords.x, stageCoords.y)){
+            return false;
+        }
+
+        // 输入框/表达式编辑器必须放行给原版（聚焦、进入编辑）。
+        // 上游 "fix accidental statement dragging" 把普通点击改为进入候选拖动并吞掉事件，
+        // 导致语句上的 TextField 收不到 touchDown、无法聚焦（B12.4 回归）。
+        if(isClickOnEditable(target)){
             return false;
         }
 


### PR DESCRIPTION
## 问题

Neon B12.4 用户实测：逻辑编辑器里**所有语句（含原版语句）的输入框都无法点击聚焦**（"所有输入框选不中"），但按钮/下拉选择正常；B12.3 无此问题。

## 根因

`fix accidental statement dragging`（v2.1.7，694a3bf）重写了 BoxSelect 的点击处理：普通点击语句积木从"放行给原版"改为"进入候选拖动状态（PENDING_SINGLE_DRAG）"，并 `event.stop()` + 返回 true 吞掉事件，防止误触拖动。

但**语句上的 TextField 输入框也命中"普通点击语句"分支**——点击输入框同样被吞掉，TextField 收不到 touchDown，永远无法聚焦。按钮/下拉因 BoxSelect 已有的按钮放行检查（isClickOnButton / Button 祖先检测）不受影响。

## 修复

`BoxSelect.handleTouchDown` 增加输入框放行检查（在候选拖动逻辑之前）：

```java
// 输入框/表达式编辑器必须放行给原版（聚焦、进入编辑）
if(isClickOnEditable(target)) return false;
```

`isClickOnEditable` 检查点击目标自身及祖先链是否含 `TextField` 或 `ExpressionEditor`（LogicSugar 的表达式编辑器组件），命中则直接放行，恢复输入框正常聚焦。

已验证：输入框可正常聚焦编辑，积木拖动/选择/框选等原有功能不受影响。