### PR TITLE
LogicSugar: 条件语句支持 Expr 表达式模式，修复拖拽布局问题

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -91,7 +91,6 @@ logicsugar.lst.return = Return: ends the current function call, optionally handi
 logicsugar.lst.break = Break: exits the innermost loop or switch.
 logicsugar.lst.continue = Continue: skips to the next iteration of the innermost loop.
 logicsugar.lst.blockend = End: closes the nearest open block.
-logicsugar.lst.expr = Expression: evaluates an expression into a variable.
 setting.logicsugar.funclib.name = Function Library
 setting.logicsugar.funclib.description = Define global functions shared by every logic processor
 logicsugar.funclib.edit = Edit in Processor

--- a/assets/bundles/bundle_zh_CN.properties
+++ b/assets/bundles/bundle_zh_CN.properties
@@ -90,7 +90,6 @@ logicsugar.lst.return = 返回：结束当前函数调用，可携带返回值�
 logicsugar.lst.break = 跳出：退出最近的循环或 switch。
 logicsugar.lst.continue = 继续：跳到最近循环的下一次迭代。
 logicsugar.lst.blockend = 结束：闭合最近的未闭合块。
-logicsugar.lst.expr = 表达式：将表达式计算结果存入变量。
 setting.logicsugar.funclib.name = 函数库
 setting.logicsugar.funclib.description = 定义全局函数，所有逻辑处理器共享
 logicsugar.funclib.edit = 在处理器中编辑

--- a/assets/bundles/bundle_zh_TW.properties
+++ b/assets/bundles/bundle_zh_TW.properties
@@ -91,7 +91,6 @@ logicsugar.lst.return = 回傳：結束目前函式呼叫，可攜帶回傳值�
 logicsugar.lst.break = 跳出：退出最近的迴圈或 switch。
 logicsugar.lst.continue = 繼續：跳到最近迴圈的下一次迭代。
 logicsugar.lst.blockend = 結束：閉合最近的未閉合區塊。
-logicsugar.lst.expr = 運算式：將運算式計算結果存入變數。
 setting.logicsugar.funclib.name = 函式庫
 setting.logicsugar.funclib.description = 定義由每個邏輯處理器共用的全域函式
 logicsugar.funclib.edit = 在處理器中編輯

--- a/src/logicsugar/assist/BoxSelect.java
+++ b/src/logicsugar/assist/BoxSelect.java
@@ -86,6 +86,7 @@ public class BoxSelect{
     private static final Field draggingField;
     private static final Field privilegedField;
     static Field needsLayoutField;
+    private static final Field dragLayoutSpaceField;
     static{
         try{
             draggingField = LCanvas.class.getDeclaredField("dragging");
@@ -94,9 +95,38 @@ public class BoxSelect{
             privilegedField.setAccessible(true);
             needsLayoutField = arc.scene.ui.layout.WidgetGroup.class.getDeclaredField("needsLayout");
             needsLayoutField.setAccessible(true);
+            dragLayoutSpaceField = LCanvas.DragLayout.class.getDeclaredField("space");
+            dragLayoutSpaceField.setAccessible(true);
         }catch(Exception e){
             Log.err("[LogicAssist] Failed to access LCanvas fields", e);
             throw new RuntimeException(e);
+        }
+    }
+
+    /** 读取 DragLayout 当前实际间距。SugarCanvas 会把 space 反射设为 0f（紧凑布局），
+     *  拖拽几何必须与布局几何用同一个值，否则拖动时积木间会凭空多出 10f 间距、
+     *  底部积木被推出可视区而滚动条不变。读取失败时退回原生默认值。 */
+    private static float getLayoutSpace(LCanvas canvas){
+        try{
+            return dragLayoutSpaceField.getFloat(canvas.statements);
+        }catch(Exception e){
+            return Scl.scl(10f);
+        }
+    }
+
+    /** 临时修改 DragLayout.space 并立即重排：拖动期间用 10f 间距把积木分得更开，
+     *  DragLayout 高度随之增大，滚动条范围同步扩大；结束拖动时传 0f 恢复紧凑布局。 */
+    private static void setDragLayoutSpace(LCanvas canvas, float space){
+        try{
+            dragLayoutSpaceField.setFloat(canvas.statements, space);
+            // 高度变化需要双重 invalidate+validate（参考 finalizeLayout）：
+            // 第一次 layout 用旧 height 执行并标记父节点，第二次用新 height 真正重排。
+            canvas.statements.invalidate();
+            canvas.statements.validate();
+            canvas.statements.invalidate();
+            canvas.statements.validate();
+        }catch(Exception e){
+            Log.warn("[LogicAssist] Failed to set layout space", e);
         }
     }
 
@@ -133,6 +163,11 @@ public class BoxSelect{
 
     // 拖动期间保存的原始 child.y（用于恢复 layout() 的修改）
     private static float[] dragBaseYs = null;
+
+    // 布局切换补偿：startDrag 时把 space 从 0f 切到 10f 会触发 layout 重排，
+    // 所有积木整体上移 10f×(N-i)。记录切换前后的 y 差，拖动时加回 translation，
+    // 保证被拖积木锚定在按下点，避免鼠标相对积木偏移（blockend 等高小的块尤甚）。
+    private static float[] dragYOffsets = null;
 
     // 插入指示器几何位置
     private static float indicatorX, indicatorY, indicatorW, indicatorH;
@@ -773,8 +808,12 @@ public class BoxSelect{
 
     private static void resetState(LCanvas canvas){
         clearDraggingField(canvas);
+        // 兜底恢复紧凑布局（若拖动中对话框被关闭等场景）
+        setDragLayoutSpace(canvas, 0f);
         restoreButtonIcons(canvas);
         resetAllTranslations(canvas);
+        dragBaseYs = null;
+        dragYOffsets = null;
         clearPendingSingleDrag();
         singleStatementDrag = false;
         singleStatementDragKeepsSelection = false;
@@ -799,20 +838,36 @@ public class BoxSelect{
         dragInsertPos = -1;
         dragMoved = false;
 
-        // 保存所有积木的原始 y 坐标（layout() 会修改，拖动期间需要恢复）
+        // 清除原版 dragging 字段，防止原版 layout 跳过错误积木
+        clearDraggingField(canvas);
+
+        // 切换布局前记录每个积木的 y（0f 间距布局），用于计算切换补偿。
+        // setDragLayoutSpace(10f) 会触发重排，所有积木上移 (N-i)×10f，
+        // 若不补偿，被拖积木相对鼠标锚点会整体偏移（blockend 等高小的块尤其明显）。
         Seq<Element> children = canvas.statements.getChildren();
+        float[] yBefore = new float[children.size];
+        for(int i = 0; i < children.size; i++){
+            yBefore[i] = children.get(i).y;
+        }
+
+        // 拖动期间把积木间距切到 10f（分得更开，方便操作），并立即重排，
+        // 让 DragLayout 高度/滚动条范围同步变大。结束拖动时恢复 0f。
+        setDragLayoutSpace(canvas, Scl.scl(10f));
+
+        // 保存所有积木的原始 y 坐标（layout() 会修改，拖动期间需要恢复）。
+        // 注意：必须在 setDragLayoutSpace 重排之后记录，基准才是 10f 间距的布局。
         dragBaseYs = new float[children.size];
+        dragYOffsets = new float[children.size];
         for(int i = 0; i < children.size; i++){
             dragBaseYs[i] = children.get(i).y;
+            // 补偿 = 切换前位置 - 切换后位置：让被拖积木视觉上仍锚定在按下点
+            dragYOffsets[i] = yBefore[i] - dragBaseYs[i];
         }
 
         // 拖动模式：dragMode 持久模式 + Ctrl/中键临时覆盖。
         // 框选框/高亮框颜色由 getModeColor() 实时反映此判断，保证与松手后拖动模式一致。
         boolean ctrlDown = Core.input.keyDown(KeyCode.controlLeft);
         boolean isCopy = (ctrlDown && ctrlDragCopyEnabled()) || dragMode == DragMode.COPY || button == KeyCode.mouseMiddle;
-
-        // 清除原版 dragging 字段，防止原版 layout 跳过错误积木
-        clearDraggingField(canvas);
 
         if(isCopy){
             prepareCopyData(canvas);
@@ -848,26 +903,43 @@ public class BoxSelect{
         if(state == State.DRAGGING_MOVE){
             // 移动模式：紧凑排列非选中积木，消除选中积木原始位置占用的空间
             relayoutNonSelected(canvas);
-            // 选中积木用 translation 跟随鼠标
+            // 选中积木用 translation 跟随鼠标。
+            // 关键：translation.y 要加上布局切换补偿（dragYOffsets），
+            // 否则 setDragLayoutSpace(10f) 重排让积木上移后，视觉锚点不再在按下点，
+            // 鼠标会跑到积木下侧甚至块外（blockend 等高小的块尤其明显）。
             Vec2 localMouse = canvas.statements.stageToLocalCoordinates(Tmp.v2.set(mx, my));
             float dx = localMouse.x - dragStartLocalX;
             float dy = localMouse.y - dragStartLocalY;
             for(StatementElem elem : selected){
-                elem.setTranslation(dx, dy);
+                int idx = children.indexOf(elem, true);
+                float offsetY = dragYOffsets != null && idx >= 0 && idx < dragYOffsets.length ? dragYOffsets[idx] : 0f;
+                elem.setTranslation(dx, dy + offsetY);
             }
         }
         // 复制模式：原积木保持原位，预览由 drawCopyPreview() 绘制
 
-        // 计算插入位置（移动模式下用 relayoutNonSelected 后的紧凑位置）
+        // 先按上一帧的插入位置腾位，让视觉空隙出现在用户上次看到的位置，
+        // 再基于"腾位后"的视觉位置判定新插入点——否则判定用的是紧凑位置，
+        // 鼠标落在视觉空隙（如 C、D 之间）时会被误判成下一块积木的位置。
+        applyInsertShift(canvas);
         int newInsertPos = computeInsertPosition(canvas, my);
         if(newInsertPos != dragInsertPos){
+            // 插入点变化：清掉旧腾位，按新位置重新排列并腾位，保证判定与显示一致
             dragInsertPos = newInsertPos;
+            resetAllTranslations(canvas);
+            if(state == State.DRAGGING_MOVE){
+                relayoutNonSelected(canvas);
+                Vec2 localMouse = canvas.statements.stageToLocalCoordinates(Tmp.v2.set(mx, my));
+                float dx = localMouse.x - dragStartLocalX;
+                float dy = localMouse.y - dragStartLocalY;
+                for(StatementElem elem : selected){
+                    int idx = children.indexOf(elem, true);
+                    float offsetY = dragYOffsets != null && idx >= 0 && idx < dragYOffsets.length ? dragYOffsets[idx] : 0f;
+                    elem.setTranslation(dx, dy + offsetY);
+                }
+            }
+            applyInsertShift(canvas);
         }
-
-        // 腾位：将插入点下方的非选中积木向下移，撑开空间显示插入位置。
-        // 关键：用 translation 而非修改 child.y，因为 translation 会被
-        // localToAscendantCoordinates 正确计算，JumpCurve 能跟随。
-        applyInsertShift(canvas);
 
         // 腾位后更新跳转线位置——此时 translation 已反映腾位，JumpCurve 能正确定位
         SugarCanvas.refreshJumpLayer(canvas);
@@ -921,7 +993,7 @@ public class BoxSelect{
      *  这样 localToAscendantCoordinates 能正确计算，JumpCurve 跟随。 */
     private static void relayoutNonSelected(LCanvas canvas){
         Seq<Element> children = canvas.statements.getChildren();
-        float space = Scl.scl(10f);
+        float space = getLayoutSpace(canvas);
 
         // 从顶部开始紧凑排列非选中积木（用 translation 表示相对于原始位置的偏移）
         float compactY = 0; // 紧凑布局中的累积 y（从顶部开始）
@@ -952,7 +1024,7 @@ public class BoxSelect{
         if(dragInsertPos < 0 || selected.isEmpty()) return;
 
         Seq<Element> children = canvas.statements.getChildren();
-        float space = Scl.scl(10f);
+        float space = getLayoutSpace(canvas);
 
         // 腾位量 = 所有选中积木高度 + 间距，减去末尾多余的一个间距
         float shiftAmount = 0;
@@ -989,7 +1061,7 @@ public class BoxSelect{
 
         Seq<Element> children = canvas.statements.getChildren();
         float paneWidth = canvas.statements.getWidth();
-        float space = Scl.scl(10f);
+        float space = getLayoutSpace(canvas);
 
         float totalH = 0;
         for(StatementElem elem : selected){
@@ -1239,7 +1311,7 @@ public class BoxSelect{
         Seq<Element> children = canvas.statements.getChildren();
         if(children.isEmpty()) return;
 
-        float space = Scl.scl(10f);
+        float space = getLayoutSpace(canvas);
         float totalHeight = 0;
         for(Element child : children){
             totalHeight += child.getPrefHeight() + space;
@@ -1372,8 +1444,12 @@ public class BoxSelect{
     private static void executeDragMove(LCanvas canvas, int insertPos){
         clearDraggingField(canvas);
 
+        // 拖动期间是 10f 间距，移动完成后恢复紧凑布局（滚动条同步缩回）
+        setDragLayoutSpace(canvas, 0f);
+
         resetAllTranslations(canvas);
         dragBaseYs = null;
+        dragYOffsets = null;
 
         List<StatementElem> sorted = getSortedSelected(canvas);
         Seq<Element> children = canvas.statements.getChildren();
@@ -1426,8 +1502,12 @@ public class BoxSelect{
     private static void executeDragCopy(LCanvas canvas, int insertPos){
         clearDraggingField(canvas);
 
+        // 拖动期间是 10f 间距，复制完成后恢复紧凑布局（滚动条同步缩回）
+        setDragLayoutSpace(canvas, 0f);
+
         resetAllTranslations(canvas);
         dragBaseYs = null;
+        dragYOffsets = null;
 
         if(clipboardCopies == null || clipboardCopies.isEmpty()){
             enterSelectedState(canvas);
@@ -1475,8 +1555,12 @@ public class BoxSelect{
     private static void cancelDrag(LCanvas canvas){
         clearDraggingField(canvas);
 
+        // 拖动期间是 10f 间距，取消后恢复紧凑布局（滚动条同步缩回）
+        setDragLayoutSpace(canvas, 0f);
+
         resetAllTranslations(canvas);
         dragBaseYs = null;
+        dragYOffsets = null;
         clipboardCopies = null;
         clipboardSize = 0;
         clipboardSources = null;
@@ -1488,8 +1572,12 @@ public class BoxSelect{
     /** Delete 键快速删除选中积木 */
     private static void deleteSelected(LCanvas canvas){
         clearDraggingField(canvas);
+        // 兜底恢复紧凑布局（删除可从任何状态进入）
+        setDragLayoutSpace(canvas, 0f);
 
         resetAllTranslations(canvas);
+        dragBaseYs = null;
+        dragYOffsets = null;
 
         List<StatementElem> sorted = getSortedSelected(canvas);
         int count = sorted.size();

--- a/src/logicsugar/assist/expr/ExpressionEditor.java
+++ b/src/logicsugar/assist/expr/ExpressionEditor.java
@@ -148,4 +148,9 @@ public class ExpressionEditor extends Stack{
     public float getPrefWidth(){
         return 0f;
     }
+
+    @Override
+    public float getMinWidth(){
+        return 80f;
+    }
 }

--- a/src/mindustry/logic/SugarCanvas.java
+++ b/src/mindustry/logic/SugarCanvas.java
@@ -27,7 +27,9 @@ import mindustry.logic.SugarStatements.BlockEndStatement;
 import mindustry.logic.SugarStatements.CaseStatement;
 import mindustry.logic.SugarStatements.ElseIfStatement;
 import mindustry.logic.SugarStatements.ElseStatement;
+import mindustry.logic.SugarStatements.ForBeginStatement;
 import mindustry.logic.SugarStatements.IfBeginStatement;
+import mindustry.logic.SugarStatements.WhileBeginStatement;
 import mindustry.logic.SugarStatements.SwitchBeginStatement;
 import logicsugar.assist.BoxSelect;
 import logicsugar.assist.JumpLineColor;
@@ -350,7 +352,15 @@ public class SugarCanvas extends LCanvas{
             float unit = Core.graphics.isPortrait() ? 17f : 24f;
             float minWidth = Core.graphics.isPortrait() ? 285f : 360f;
             float maxInset = Math.max(0f, getWidth() / Scl.scl(1f) - minWidth);
-            float nextInset = Math.min(Math.max(0, structureDepth) * unit, maxInset);
+            // 缩进深度封顶：嵌套过深时不再继续增加缩进，避免内容区被挤到只剩
+            // minWidth 甚至更窄。语句内部文本/输入框不会自动换行，缩进无上限时
+            // 深嵌套会把行内容挤到无法阅读（横屏 900 宽下 22 层就达到 540 极限）。
+            // 封顶取 3 层：for 等宽语句的行尾按钮（EXPR/OP/折叠）在深缩进时会被
+            // 顶出屏幕，且 for 本身多行+行尾按钮，缩进 4 层（96px）已能把
+            // EXPR/OP 顶出可视区。3 层（横屏 72px）进一步收紧，保证行尾按钮可见。
+            float maxDepth = 3f;
+            float depthInset = Math.min(Math.max(0, structureDepth), maxDepth) * unit;
+            float nextInset = Math.min(depthInset, maxInset);
             if(Math.abs(inset - nextInset) > 0.1f){
                 inset = nextInset;
                 marginLeft(inset);
@@ -493,6 +503,21 @@ public class SugarCanvas extends LCanvas{
                 if(elem.st instanceof BeginStatement begin){
                     nextSignature = 31 * nextSignature + System.identityHashCode(begin.dest);
                     nextSignature = 31 * nextSignature + (begin.collapsed ? 1 : 0);
+                }
+                // Condition content changes (typing in the Expr editor, switching op/Expr mode)
+                // must re-run invalidStatements, or stale red marking never refreshes.
+                if(elem.st instanceof IfBeginStatement ifBegin){
+                    nextSignature = 31 * nextSignature + (ifBegin.expressionMode ? 1 : 0);
+                    nextSignature = 31 * nextSignature + ifBegin.conditionExpr.hashCode();
+                }else if(elem.st instanceof ElseIfStatement elseIf){
+                    nextSignature = 31 * nextSignature + (elseIf.expressionMode ? 1 : 0);
+                    nextSignature = 31 * nextSignature + elseIf.conditionExpr.hashCode();
+                }else if(elem.st instanceof WhileBeginStatement whileBegin){
+                    nextSignature = 31 * nextSignature + (whileBegin.expressionMode ? 1 : 0);
+                    nextSignature = 31 * nextSignature + whileBegin.conditionExpr.hashCode();
+                }else if(elem.st instanceof ForBeginStatement forBegin){
+                    nextSignature = 31 * nextSignature + (forBegin.expressionMode ? 1 : 0);
+                    nextSignature = 31 * nextSignature + forBegin.conditionExpr.hashCode();
                 }
             }
             if(nextSignature == signature) return;

--- a/src/mindustry/logic/SugarCompiler.java
+++ b/src/mindustry/logic/SugarCompiler.java
@@ -18,6 +18,7 @@ import mindustry.logic.SugarStatements.IfBeginStatement;
 import mindustry.logic.SugarStatements.ReturnStatement;
 import mindustry.logic.SugarStatements.SwitchBeginStatement;
 import mindustry.logic.SugarStatements.WhileBeginStatement;
+import logicsugar.assist.expr.ExprCompiler;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
@@ -379,6 +380,18 @@ public final class SugarCompiler{
             if(statements.get(i) instanceof ReturnStatement && funcOwner[i] < 0){
                 invalid[i] = true;
             }
+            if(statements.get(i) instanceof IfBeginStatement ifBegin && ifBegin.expressionMode){
+                invalid[i] |= !validConditionExpression(ifBegin.conditionExpr);
+            }
+            if(statements.get(i) instanceof ElseIfStatement elseIf && elseIf.expressionMode){
+                invalid[i] |= !validConditionExpression(elseIf.conditionExpr);
+            }
+            if(statements.get(i) instanceof WhileBeginStatement whileBegin && whileBegin.expressionMode){
+                invalid[i] |= !validConditionExpression(whileBegin.conditionExpr);
+            }
+            if(statements.get(i) instanceof ForBeginStatement forBegin && forBegin.expressionMode){
+                invalid[i] |= !validConditionExpression(forBegin.conditionExpr);
+            }
         }
 
         // an if chain may have at most one else, and no elif may follow it (shared rule,
@@ -401,6 +414,15 @@ public final class SugarCompiler{
             }
         }
         return invalid;
+    }
+
+    private static boolean validConditionExpression(String expression){
+        try{
+            ExprCompiler.compile("__ls_cond_check", expression);
+            return true;
+        }catch(Exception ignored){
+            return false;
+        }
     }
 
     public static FuncMode currentMode(){

--- a/src/mindustry/logic/SugarFunctions.java
+++ b/src/mindustry/logic/SugarFunctions.java
@@ -1032,6 +1032,51 @@ public final class SugarFunctions{
                 rewritten.add(copy);
                 continue;
             }
+            if(statement instanceof IfBeginStatement ifBegin && ifBegin.expressionMode){
+                IfBeginStatement copy = new IfBeginStatement();
+                copy.value = ifBegin.value;
+                copy.compare = ifBegin.compare;
+                copy.op = ifBegin.op;
+                copy.expressionMode = true;
+                copy.conditionExpr = rewriteExpression(ifBegin.conditionExpr, map);
+                copy.destIndex = ifBegin.destIndex;
+                rewritten.add(copy);
+                continue;
+            }
+            if(statement instanceof ElseIfStatement elseIf && elseIf.expressionMode){
+                ElseIfStatement copy = new ElseIfStatement();
+                copy.value = elseIf.value;
+                copy.compare = elseIf.compare;
+                copy.op = elseIf.op;
+                copy.expressionMode = true;
+                copy.conditionExpr = rewriteExpression(elseIf.conditionExpr, map);
+                rewritten.add(copy);
+                continue;
+            }
+            if(statement instanceof WhileBeginStatement whileBegin && whileBegin.expressionMode){
+                WhileBeginStatement copy = new WhileBeginStatement();
+                copy.value = whileBegin.value;
+                copy.compare = whileBegin.compare;
+                copy.op = whileBegin.op;
+                copy.expressionMode = true;
+                copy.conditionExpr = rewriteExpression(whileBegin.conditionExpr, map);
+                copy.destIndex = whileBegin.destIndex;
+                rewritten.add(copy);
+                continue;
+            }
+            if(statement instanceof ForBeginStatement forBegin && forBegin.expressionMode){
+                ForBeginStatement copy = new ForBeginStatement();
+                copy.variable = forBegin.variable;
+                copy.initial = forBegin.initial;
+                copy.step = forBegin.step;
+                copy.compare = forBegin.compare;
+                copy.op = forBegin.op;
+                copy.expressionMode = true;
+                copy.conditionExpr = rewriteExpression(forBegin.conditionExpr, map);
+                copy.destIndex = forBegin.destIndex;
+                rewritten.add(copy);
+                continue;
+            }
             StringBuilder text = new StringBuilder();
             statement.write(text);
             String rewrittenText = rewriteTokens(text.toString(), map);
@@ -1166,13 +1211,23 @@ public final class SugarFunctions{
             if(statement instanceof ForBeginStatement begin){
                 if(!begin.initial.isEmpty()) out.append("set ").append(begin.variable).append(' ').append(begin.initial).append('\n');
                 out.append(label(prefix, "for_check_", i)).append(":\n");
-                out.append("jump ").append(label(prefix, "for_body_", i)).append(' ').append(begin.op.name()).append(' ')
-                    .append(begin.variable).append(' ').append(begin.compare).append('\n');
+                if(begin.expressionMode){
+                    String condition = emitConditionExpression(begin.conditionExpr, prefix, i, out);
+                    out.append("jump ").append(label(prefix, "for_body_", i)).append(" notEqual ").append(condition).append(" 0\n");
+                }else{
+                    out.append("jump ").append(label(prefix, "for_body_", i)).append(' ').append(begin.op.name()).append(' ')
+                        .append(begin.variable).append(' ').append(begin.compare).append('\n');
+                }
                 out.append("jump ").append(label(prefix, "stmt_", begin.destIndex + 1)).append(" always x false\n");
                 out.append(label(prefix, "for_body_", i)).append(":\n");
             }else if(statement instanceof WhileBeginStatement begin){
-                out.append("jump ").append(label(prefix, "while_body_", i)).append(' ').append(begin.op.name()).append(' ')
-                    .append(begin.value).append(' ').append(begin.compare).append('\n');
+                if(begin.expressionMode){
+                    String condition = emitConditionExpression(begin.conditionExpr, prefix, i, out);
+                    out.append("jump ").append(label(prefix, "while_body_", i)).append(" notEqual ").append(condition).append(" 0\n");
+                }else{
+                    out.append("jump ").append(label(prefix, "while_body_", i)).append(' ').append(begin.op.name()).append(' ')
+                        .append(begin.value).append(' ').append(begin.compare).append('\n');
+                }
                 out.append("jump ").append(label(prefix, "stmt_", begin.destIndex + 1)).append(" always x false\n");
                 out.append(label(prefix, "while_body_", i)).append(":\n");
             }else if(statement instanceof SwitchBeginStatement begin){
@@ -1189,10 +1244,15 @@ public final class SugarFunctions{
                 String target = nextBranch[i] >= 0
                     ? label(prefix, "if_branch_", nextBranch[i])
                     : label(prefix, "stmt_", begin.destIndex + 1);
-                ConditionOp negated = negate(begin.op);
-                if(negated != null){
-                    out.append("jump ").append(target).append(' ').append(negated.name()).append(' ')
-                        .append(begin.value).append(' ').append(begin.compare).append('\n');
+                if(begin.expressionMode){
+                    String condition = emitConditionExpression(begin.conditionExpr, prefix, i, out);
+                    out.append("jump ").append(target).append(" equal ").append(condition).append(" 0\n");
+                }else{
+                    ConditionOp negated = negate(begin.op);
+                    if(negated != null){
+                        out.append("jump ").append(target).append(' ').append(negated.name()).append(' ')
+                            .append(begin.value).append(' ').append(begin.compare).append('\n');
+                    }
                 }
             }else if(statement instanceof ElseIfStatement item){
                 int owner = ifOwner[i];
@@ -1203,10 +1263,15 @@ public final class SugarFunctions{
                 String target = nextBranch[i] >= 0
                     ? label(prefix, "if_branch_", nextBranch[i])
                     : label(prefix, "stmt_", end + 1);
-                ConditionOp negated = negate(item.op);
-                if(negated != null){
-                    out.append("jump ").append(target).append(' ').append(negated.name()).append(' ')
-                        .append(item.value).append(' ').append(item.compare).append('\n');
+                if(item.expressionMode){
+                    String condition = emitConditionExpression(item.conditionExpr, prefix, i, out);
+                    out.append("jump ").append(target).append(" equal ").append(condition).append(" 0\n");
+                }else{
+                    ConditionOp negated = negate(item.op);
+                    if(negated != null){
+                        out.append("jump ").append(target).append(' ').append(negated.name()).append(' ')
+                            .append(item.value).append(' ').append(item.compare).append('\n');
+                    }
                 }
             }else if(statement instanceof ElseStatement){
                 int owner = ifOwner[i];
@@ -1260,6 +1325,33 @@ public final class SugarFunctions{
             }
         }
         if(statementLabels[statements.size]) out.append(label(prefix, "stmt_", statements.size)).append(":\n");
+    }
+
+    /** Compiles an if/elif expression into a compiler-private boolean temporary. */
+    private static String emitConditionExpression(String expression, String prefix, int statementIndex, StringBuilder out){
+        List<ExprCompiler.OpLine> ops;
+        String base = "__ls_cond_" + prefix.replace('-', '_') + statementIndex;
+        String dest = base;
+        try{
+            ops = ExprCompiler.compile(dest, expression);
+        }catch(Exception e){
+            throw new IllegalArgumentException("Invalid condition expression '" + expression + "': " + e.getMessage());
+        }
+        for(ExprCompiler.OpLine op : ops){
+            String a = renameConditionTemp(op.a, prefix, statementIndex);
+            String b = renameConditionTemp(op.b, prefix, statementIndex);
+            String d = renameConditionTemp(op.dest, prefix, statementIndex);
+            out.append("op ").append(op.op).append(' ').append(d).append(' ').append(a).append(' ').append(b).append('\n');
+        }
+        return dest;
+    }
+
+    private static String renameConditionTemp(String value, String prefix, int statementIndex){
+        if(!ExprCompiler.isTemp(value)) return value;
+        // ExprCompiler may reuse the destination temporary as an operand; preserve the
+        // generated condition's base name and append the temporary suffix only for _0+.
+        return "__ls_cond_" + prefix.replace('-', '_') + statementIndex
+            + ("_0".equals(value) ? "" : value.substring(1));
     }
 
     private static void emitReturn(ReturnStatement ret, String prefix, FuncMode mode, StringBuilder out, String funcName){

--- a/src/mindustry/logic/SugarStatements.java
+++ b/src/mindustry/logic/SugarStatements.java
@@ -58,6 +58,54 @@ public final class SugarStatements{
         }
     }
 
+    /**
+     * Shared condition editor for if/elif/for/while: the native three-part selector on the
+     * left, an EXPR/OP mode toggle on the right. The row colour follows the statement card
+     * every frame, so invalid-state red marking can never leave a stale snapshot behind.
+     */
+    private static void rebuildConditionEditor(LStatement owner, Table table, boolean expressionMode, String expr,
+                                               Cons<String> setExpr, Runnable enterExpr, Runnable leaveExpr,
+                                               ConditionOp op, Cons<ConditionOp> setOp,
+                                               String value, Cons<String> setValue,
+                                               String compare, Cons<String> setCompare,
+                                               Runnable rebuild){
+        table.clearChildren();
+        table.left();
+        table.update(() -> {
+            Color target = owner.elem == null ? Pal.logicControl : owner.elem.color;
+            table.setColor(target);
+            for(Element child : table.getChildren()){
+                child.setColor(target);
+            }
+        });
+        if(expressionMode){
+            table.add(new ExpressionEditor(expr, text("condition.expr.hint", "a > b && enabled"), setExpr))
+                .growX().fillX().pad(4f);
+            // 显示当前状态：Expr 模式下按钮显示 "Expr"，点击切回三段式
+            table.button(b -> {
+                b.add(text("condition.expr", "Expr"));
+                b.clicked(() -> {
+                    leaveExpr.run();
+                    rebuild.run();
+                });
+            }, Styles.logict, () -> {}).size(72f, 40f).pad(4f).color(table.color);
+        }else{
+            JumpStatement.addOp(owner, table, op, result -> {
+                setOp.get(result);
+                rebuild.run();
+            }, value, setValue, compare, setCompare);
+            table.add().growX();
+            // 显示当前状态：三段式模式下按钮显示 "op"，点击切换为表达式
+            table.button(b -> {
+                b.add(text("condition.expr.back", "op"));
+                b.clicked(() -> {
+                    enterExpr.run();
+                    rebuild.run();
+                });
+            }, Styles.logict, () -> {}).size(48f, 40f).pad(4f).color(table.color);
+        }
+    }
+
     public abstract static class BeginStatement extends SugarStatement{
         public transient StatementElem dest;
         public int destIndex = -1;
@@ -71,10 +119,15 @@ public final class SugarStatements{
         }
 
         protected void foldControl(Table table){
-            var fold = table.button(collapsed ? mindustry.gen.Icon.rightOpen : mindustry.gen.Icon.downOpen, mindustry.ui.Styles.logici, () -> {
+            // logici draws a plain black glyph with no background, which vanishes on the
+            // tinted statement card; use a visible background with a light icon instead.
+            arc.scene.ui.ImageButton.ImageButtonStyle foldStyle = new arc.scene.ui.ImageButton.ImageButtonStyle(mindustry.ui.Styles.logici);
+            foldStyle.up = mindustry.ui.Styles.logict.up;
+            foldStyle.imageUpColor = arc.graphics.Color.white;
+            var fold = table.button(collapsed ? mindustry.gen.Icon.rightOpen : mindustry.gen.Icon.downOpen, foldStyle, () -> {
                 collapsed = !collapsed;
                 SugarCanvas.refreshCurrent();
-            }).size(30f).padRight(2f).tooltip(text("fold", "Fold block")).get();
+            }).size(34f, 40f).pad(4f).tooltip(text("fold", "Fold block")).get();
             fold.update(() -> fold.getStyle().imageUp = collapsed ? mindustry.gen.Icon.rightOpen : mindustry.gen.Icon.downOpen);
         }
 
@@ -145,30 +198,33 @@ public final class SugarStatements{
     public static class ForBeginStatement extends BeginStatement{
         public String variable = "i", initial = "0", step = "1", compare = "10";
         public ConditionOp op = ConditionOp.lessThanEq;
+        /** When true, conditionExpr replaces the variable/operator/compare triplet. */
+        public boolean expressionMode;
+        public String conditionExpr = "true";
 
         @Override
         public void build(Table table){
-            // Vanilla-style "label + input": fields() adds the label and field as separate
-            // left-aligned cells, so nothing gets centered.
             fieldsHint(table, text("for.variable", "variable"), "for.variable", variable, value -> variable = value);
             row(table);
             fieldsHint(table, text("for.initial", "initial"), "for.initial", initial, value -> initial = value);
             row(table);
             fieldsHint(table, text("for.step", "step"), "for.step", step, value -> step = value);
             row(table);
-            // 终止条件：描述 + 三段式（value op compare）
+            // 终止条件：描述 + 三段式（value op compare）或 Expr
             table.add(text("for.condition", "until")).padLeft(10).left().self(c -> hint(c, "for.condition"));
-            table.table(this::rebuildCondition);
+            table.table(this::rebuildCondition).growX().fillX();
             foldControl(table);
         }
 
         private void rebuildCondition(Table table){
-            table.clearChildren();
-            table.setColor(elem == null ? Pal.logicControl : elem.color);
-            JumpStatement.addOp(this, table, op, result -> {
-                op = result;
-                rebuildCondition(table);
-            }, variable, result -> variable = result, compare, result -> compare = result);
+            rebuildConditionEditor(this, table, expressionMode, conditionExpr,
+                result -> conditionExpr = result,
+                () -> expressionMode = true,
+                () -> expressionMode = false,
+                op, result -> op = result,
+                variable, result -> variable = result,
+                compare, result -> compare = result,
+                () -> rebuildCondition(table));
         }
 
         @Override public String name(){ return text("for.begin", "For Begin"); }
@@ -176,34 +232,51 @@ public final class SugarStatements{
 
         @Override
         public void write(StringBuilder out){
-            out.append(collapsed ? "forbeginc " : "forbegin ").append(variable).append(' ').append(optional(initial)).append(' ').append(optional(step)).append(' ')
-                .append(op.name()).append(' ').append(compare).append(' ').append(destIndex);
+            if(expressionMode){
+                out.append(collapsed ? "forbeginc " : "forbegin ").append(variable).append(' ')
+                    .append(optional(initial)).append(' ').append(optional(step)).append(" expr \"")
+                    .append(conditionExpr).append("\" ").append(destIndex);
+            }else{
+                out.append(collapsed ? "forbeginc " : "forbegin ").append(variable).append(' ').append(optional(initial)).append(' ').append(optional(step)).append(' ')
+                    .append(op.name()).append(' ').append(compare).append(' ').append(destIndex);
+            }
         }
     }
 
     public static class WhileBeginStatement extends BeginStatement{
         public String value = "true", compare = "false";
         public ConditionOp op = ConditionOp.notEqual;
+        public boolean expressionMode;
+        public String conditionExpr = "true";
 
         @Override
         public void build(Table table){
             table.add(text("condition", "condition")).self(c -> hint(c, "while.condition"));
-            table.table(this::rebuildCondition);
+            table.table(this::rebuildCondition).growX().fillX();
             foldControl(table);
         }
 
         private void rebuildCondition(Table table){
-            table.clearChildren();
-            table.setColor(elem == null ? Pal.logicControl : elem.color);
-            JumpStatement.addOp(this, table, op, result -> {
-                op = result;
-                rebuildCondition(table);
-            }, value, result -> value = result, compare, result -> compare = result);
+            rebuildConditionEditor(this, table, expressionMode, conditionExpr,
+                result -> conditionExpr = result,
+                () -> expressionMode = true,
+                () -> expressionMode = false,
+                op, result -> op = result,
+                value, result -> value = result,
+                compare, result -> compare = result,
+                () -> rebuildCondition(table));
         }
 
         @Override public String name(){ return text("while.begin", "While Begin"); }
         @Override public String typeName(){ return "WhileBegin"; }
-        @Override public void write(StringBuilder out){ out.append(collapsed ? "whilebeginc " : "whilebegin ").append(value).append(' ').append(op.name()).append(' ').append(compare).append(' ').append(destIndex); }
+        @Override public void write(StringBuilder out){
+            if(expressionMode){
+                out.append(collapsed ? "whilebeginc " : "whilebegin ").append("expr \"")
+                    .append(conditionExpr).append("\" ").append(destIndex);
+            }else{
+                out.append(collapsed ? "whilebeginc " : "whilebegin ").append(value).append(' ').append(op.name()).append(' ').append(compare).append(' ').append(destIndex);
+            }
+        }
     }
 
     public static class SwitchBeginStatement extends BeginStatement{
@@ -235,50 +308,73 @@ public final class SugarStatements{
     public static class IfBeginStatement extends BeginStatement{
         public String value = "true", compare = "false";
         public ConditionOp op = ConditionOp.notEqual;
+        /** When true, conditionExpr replaces the native value/operator/compare triplet. */
+        public boolean expressionMode;
+        public String conditionExpr = "true";
 
         @Override
         public void build(Table table){
             table.add(text("if.condition", "if")).self(c -> hint(c, "if.condition"));
-            table.table(this::rebuildCondition);
+            table.table(this::rebuildCondition).growX().fillX();
             foldControl(table);
         }
 
         private void rebuildCondition(Table table){
-            table.clearChildren();
-            table.setColor(elem == null ? Pal.logicControl : elem.color);
-            JumpStatement.addOp(this, table, op, result -> {
-                op = result;
-                rebuildCondition(table);
-            }, value, result -> value = result, compare, result -> compare = result);
+            rebuildConditionEditor(this, table, expressionMode, conditionExpr,
+                result -> conditionExpr = result,
+                () -> expressionMode = true,
+                () -> expressionMode = false,
+                op, result -> op = result,
+                value, result -> value = result,
+                compare, result -> compare = result,
+                () -> rebuildCondition(table));
         }
 
         @Override public String name(){ return text("if.begin", "If Begin"); }
         @Override public String typeName(){ return "IfBegin"; }
-        @Override public void write(StringBuilder out){ out.append(collapsed ? "ifbeginc " : "ifbegin ").append(value).append(' ').append(op.name()).append(' ').append(compare).append(' ').append(destIndex); }
+        @Override public void write(StringBuilder out){
+            if(expressionMode){
+                out.append(collapsed ? "ifbeginc expr \"" : "ifbegin expr \"")
+                    .append(conditionExpr).append("\" ").append(destIndex);
+            }else{
+                out.append(collapsed ? "ifbeginc " : "ifbegin ").append(value).append(' ')
+                    .append(op.name()).append(' ').append(compare).append(' ').append(destIndex);
+            }
+        }
     }
 
     public static class ElseIfStatement extends SugarStatement{
         public String value = "true", compare = "false";
         public ConditionOp op = ConditionOp.notEqual;
+        public boolean expressionMode;
+        public String conditionExpr = "true";
 
         @Override
         public void build(Table table){
             table.add(text("elif", "elif")).self(c -> hint(c, "elif"));
-            table.table(this::rebuildCondition);
+            table.table(this::rebuildCondition).growX().fillX();
         }
 
         private void rebuildCondition(Table table){
-            table.clearChildren();
-            table.setColor(elem == null ? Pal.logicControl : elem.color);
-            JumpStatement.addOp(this, table, op, result -> {
-                op = result;
-                rebuildCondition(table);
-            }, value, result -> value = result, compare, result -> compare = result);
+            rebuildConditionEditor(this, table, expressionMode, conditionExpr,
+                result -> conditionExpr = result,
+                () -> expressionMode = true,
+                () -> expressionMode = false,
+                op, result -> op = result,
+                value, result -> value = result,
+                compare, result -> compare = result,
+                () -> rebuildCondition(table));
         }
 
         @Override public String name(){ return text("elif", "Elif"); }
         @Override public String typeName(){ return "ElseIf"; }
-        @Override public void write(StringBuilder out){ out.append("elif ").append(value).append(' ').append(op.name()).append(' ').append(compare); }
+        @Override public void write(StringBuilder out){
+            if(expressionMode){
+                out.append("elif expr \"").append(conditionExpr).append("\"");
+            }else{
+                out.append("elif ").append(value).append(' ').append(op.name()).append(' ').append(compare);
+            }
+        }
     }
 
     public static class ElseStatement extends SugarStatement{
@@ -410,8 +506,13 @@ public final class SugarStatements{
         result.variable = tokens[1];
         result.initial = optionalValue(tokens[2]);
         result.step = optionalValue(tokens[3]);
-        result.op = ConditionOp.valueOf(tokens[4]);
-        result.compare = tokens[5];
+        if("expr".equals(tokens[4])){
+            result.expressionMode = true;
+            result.conditionExpr = stripQuotes(tokens[5]);
+        }else{
+            result.op = ConditionOp.valueOf(tokens[4]);
+            result.compare = tokens[5];
+        }
         result.destIndex = Integer.parseInt(tokens[6]);
         result.collapsed = collapsed;
         return result;
@@ -423,18 +524,26 @@ public final class SugarStatements{
 
     public static LStatement parseWhileBegin(String[] tokens, boolean collapsed){
         WhileBeginStatement result = new WhileBeginStatement();
-        ConditionOp parsedOp = parseConditionOp(tokens[2]);
-        if(parsedOp != null){
-            result.value = tokens[1];
-            result.op = parsedOp;
-            result.compare = tokens[3];
-            result.destIndex = parseDestIndex(tokens[4]);
+        // "whilebegin expr "<cond>" <destIndex>" — the quoted expression distinguishes it
+        // from a legacy variable literally named "expr".
+        if("expr".equals(tokens[1]) && tokens[2].length() >= 2 && tokens[2].charAt(0) == '"'){
+            result.expressionMode = true;
+            result.conditionExpr = stripQuotes(tokens[2]);
+            result.destIndex = parseDestIndex(tokens[3]);
         }else{
-            // legacy single-value condition: "whilebegin <cond> <destIndex>"
-            result.value = tokens[1];
-            result.op = ConditionOp.notEqual;
-            result.compare = "false";
-            result.destIndex = parseDestIndex(tokens[2]);
+            ConditionOp parsedOp = parseConditionOp(tokens[2]);
+            if(parsedOp != null){
+                result.value = tokens[1];
+                result.op = parsedOp;
+                result.compare = tokens[3];
+                result.destIndex = parseDestIndex(tokens[4]);
+            }else{
+                // legacy single-value condition: "whilebegin <cond> <destIndex>"
+                result.value = tokens[1];
+                result.op = ConditionOp.notEqual;
+                result.compare = "false";
+                result.destIndex = parseDestIndex(tokens[2]);
+            }
         }
         result.collapsed = collapsed;
         return result;
@@ -464,23 +573,39 @@ public final class SugarStatements{
 
     public static LStatement parseIfBegin(String[] tokens, boolean collapsed){
         IfBeginStatement result = new IfBeginStatement();
-        result.value = tokens[1];
-        ConditionOp op = parseConditionOp(tokens[2]);
-        if(op == null) throw new IllegalArgumentException("Invalid ifbegin condition operator: '" + tokens[2] + "'");
-        result.op = op;
-        result.compare = tokens[3];
-        result.destIndex = parseDestIndex(tokens[4]);
+        // "ifbegin expr \"<cond>\" <destIndex>" — require the quoted expression so an old
+        // save whose variable is literally named "expr" is not silently re-parsed as an
+        // expression condition (e.g. "ifbegin expr lessThan 5 4").
+        if("expr".equals(tokens[1]) && tokens.length > 2 && tokens[2].length() >= 2 && tokens[2].charAt(0) == '"'){
+            result.expressionMode = true;
+            result.conditionExpr = stripQuotes(tokens[2]);
+            result.destIndex = parseDestIndex(tokens[3]);
+        }else{
+            result.value = tokens[1];
+            ConditionOp op = parseConditionOp(tokens[2]);
+            if(op == null) throw new IllegalArgumentException("Invalid ifbegin condition operator: '" + tokens[2] + "'");
+            result.op = op;
+            result.compare = tokens[3];
+            result.destIndex = parseDestIndex(tokens[4]);
+        }
         result.collapsed = collapsed;
         return result;
     }
 
     public static LStatement parseElseIf(String[] tokens){
         ElseIfStatement result = new ElseIfStatement();
-        ConditionOp op = parseConditionOp(tokens[2]);
-        if(op == null) throw new IllegalArgumentException("Invalid elif condition operator: '" + tokens[2] + "'");
-        result.value = tokens[1];
-        result.op = op;
-        result.compare = tokens[3];
+        // Same quoted-expression guard as parseIfBegin: a variable named "expr" must not
+        // be silently re-parsed as an expression condition.
+        if("expr".equals(tokens[1]) && tokens.length > 2 && tokens[2].length() >= 2 && tokens[2].charAt(0) == '"'){
+            result.expressionMode = true;
+            result.conditionExpr = stripQuotes(tokens[2]);
+        }else{
+            ConditionOp op = parseConditionOp(tokens[2]);
+            if(op == null) throw new IllegalArgumentException("Invalid elif condition operator: '" + tokens[2] + "'");
+            result.value = tokens[1];
+            result.op = op;
+            result.compare = tokens[3];
+        }
         return result;
     }
 

--- a/test/mindustry/logic/IfElseCompileTest.java
+++ b/test/mindustry/logic/IfElseCompileTest.java
@@ -68,6 +68,41 @@ public final class IfElseCompileTest{
         System.out.println("=== legacy while ===\n" + compiledLegacyWhile);
         check(compiledLegacyWhile.contains("jump __ls_while_body_0 notEqual a false"), "legacy while maps to != false");
 
+        // Expr mode: the full condition lowers to op instructions plus a native jump.
+        String exprIf = "ifbegin expr \"a > 5 && ready\" 4\nset x 1\nelif expr \"fallback != 0\"\nset x 2\nblockend\n";
+        String compiledExpr = SugarCompiler.compile(exprIf);
+        System.out.println("=== if/elif expr ===\n" + compiledExpr);
+        check(compiledExpr.contains("op greaterThan __ls_cond_0 a 5"), "expr if comparison emitted");
+        check(compiledExpr.contains("op land __ls_cond_0 __ls_cond_0 ready"), "expr if boolean operator emitted");
+        check(compiledExpr.contains("jump __ls_if_branch_2 equal __ls_cond_0 0"), "expr if false branch emitted");
+        check(compiledExpr.contains("op notEqual __ls_cond_2 fallback 0"), "expr elif comparison emitted");
+        check(compiledExpr.contains("jump __ls_stmt_5 equal __ls_cond_2 0"), "expr elif false branch emitted");
+
+        // while with Expr condition: the condition lowers to op + a notEqual enter jump
+        String exprWhile = "whilebegin expr \"x < 10 && ready\" 2\nset y 1\nblockend\n";
+        String compiledExprWhile = SugarCompiler.compile(exprWhile);
+        System.out.println("=== while expr ===\n" + compiledExprWhile);
+        check(compiledExprWhile.contains("op lessThan __ls_cond_0 x 10"), "expr while comparison emitted");
+        check(compiledExprWhile.contains("jump __ls_while_body_0 notEqual __ls_cond_0 0"), "expr while enter jump");
+
+        // for with Expr condition
+        String exprFor = "forbegin i 0 1 expr \"i < count && go\" 2\nset y 1\nblockend\n";
+        String compiledExprFor = SugarCompiler.compile(exprFor);
+        System.out.println("=== for expr ===\n" + compiledExprFor);
+        check(compiledExprFor.contains("op lessThan __ls_cond_0 i count"), "expr for comparison emitted");
+        check(compiledExprFor.contains("jump __ls_for_body_0 notEqual __ls_cond_0 0"), "expr for body jump");
+
+        // Function body with an Expr condition referencing a function parameter:
+        // rewriteBody must rewrite the parameter inside the condition expression,
+        // otherwise the compiled call would compare against the outer variable.
+        // statements: 0=funcdef, 1=ifbegin expr, 2=set, 3=blockend(if), 4=blockend(func)
+        String funcExpr = "funcdef f a 4\nifbegin expr \"a > 0 && ready\" 3\nset x 1\nblockend\nblockend\nfunccall f \"threshold\" ~\n";
+        String compiledFuncExpr = SugarCompiler.compile(funcExpr);
+        System.out.println("=== func body expr ===\n" + compiledFuncExpr);
+        check(compiledFuncExpr.contains("op greaterThan __ls_cond_func_f_0 a 0"), "func Expr condition compiled with function-local temp");
+        check(compiledFuncExpr.contains("jump __ls_func_f_stmt_3 equal __ls_cond_func_f_0 0"), "func Expr false branch emitted");
+        check(compiledFuncExpr.contains("set a threshold"), "func Expr condition parameter bound to call argument");
+
         // invalid: elif outside if must throw
         expectFailure("elif a equal 0\n", "elif outside if rejected");
 
@@ -80,6 +115,49 @@ public final class IfElseCompileTest{
         StringBuilder text = new StringBuilder();
         ifBegin.write(text);
         check(text.toString().equals("ifbegin a greaterThan 5 3"), "ifbegin serializes via write()");
+
+        // for/while Expr serialization round-trip
+        SugarStatements.ForBeginStatement forExpr = new SugarStatements.ForBeginStatement();
+        forExpr.variable = "i";
+        forExpr.initial = "0";
+        forExpr.step = "1";
+        forExpr.expressionMode = true;
+        forExpr.conditionExpr = "i < count && go";
+        forExpr.destIndex = 4;
+        StringBuilder forText = new StringBuilder();
+        forExpr.write(forText);
+        check(forText.toString().equals("forbegin i 0 1 expr \"i < count && go\" 4"), "for expr serializes via write()");
+        LStatement parsedFor = LAssembler.read(forText.toString(), true).first();
+        check(parsedFor instanceof SugarStatements.ForBeginStatement, "for expr round-trips back to ForBeginStatement");
+        SugarStatements.ForBeginStatement parsedForExpr = (SugarStatements.ForBeginStatement)parsedFor;
+        check(parsedForExpr.expressionMode && parsedForExpr.conditionExpr.equals("i < count && go") && parsedForExpr.destIndex == 4,
+            "for expr fields survive round-trip");
+
+        SugarStatements.WhileBeginStatement whileExpr = new SugarStatements.WhileBeginStatement();
+        whileExpr.expressionMode = true;
+        whileExpr.conditionExpr = "x < 10 && ready";
+        whileExpr.destIndex = 2;
+        StringBuilder whileText = new StringBuilder();
+        whileExpr.write(whileText);
+        check(whileText.toString().equals("whilebegin expr \"x < 10 && ready\" 2"), "while expr serializes via write()");
+        LStatement parsedWhile = LAssembler.read(whileText.toString(), true).first();
+        check(parsedWhile instanceof SugarStatements.WhileBeginStatement, "while expr round-trips back to WhileBeginStatement");
+        SugarStatements.WhileBeginStatement parsedWhileExpr = (SugarStatements.WhileBeginStatement)parsedWhile;
+        check(parsedWhileExpr.expressionMode && parsedWhileExpr.conditionExpr.equals("x < 10 && ready") && parsedWhileExpr.destIndex == 2,
+            "while expr fields survive round-trip");
+
+        SugarStatements.IfBeginStatement exprStatement = new SugarStatements.IfBeginStatement();
+        exprStatement.expressionMode = true;
+        exprStatement.conditionExpr = "a > 5 && ready";
+        exprStatement.destIndex = 3;
+        StringBuilder exprText = new StringBuilder();
+        exprStatement.write(exprText);
+        check(exprText.toString().equals("ifbegin expr \"a > 5 && ready\" 3"), "expr ifbegin serializes via write()");
+        LStatement parsedExpr = LAssembler.read(exprText.toString(), true).first();
+        check(parsedExpr instanceof SugarStatements.IfBeginStatement, "expr ifbegin round-trips back to IfBeginStatement");
+        SugarStatements.IfBeginStatement parsedExprIf = (SugarStatements.IfBeginStatement)parsedExpr;
+        check(parsedExprIf.expressionMode && parsedExprIf.conditionExpr.equals("a > 5 && ready") && parsedExprIf.destIndex == 3,
+            "expr ifbegin fields survive round-trip");
         LStatement parsed = LAssembler.read(text.toString(), true).first();
         check(parsed instanceof SugarStatements.IfBeginStatement, "ifbegin round-trips back to IfBeginStatement");
         SugarStatements.IfBeginStatement parsedIf = (SugarStatements.IfBeginStatement)parsed;


### PR DESCRIPTION
## 功能

为 `if / elif / for / while` 条件语句增加 **Expr 表达式模式**：

- 三段式条件（`输入框 + 运算符 + 输入框`）与完整表达式（如 `a > b && ready`）通过按钮一键切换，按钮显示当前模式（op / Expr）
- Expr 条件复用现有 `ExprCompiler` + `ExpressionEditor`，支持运算符、括号、嵌套、函数调用
- 编译时把表达式 lower 为 op 链 + 临时布尔变量，再输出原生 jump，产物仍是标准 mlog

## 实现要点

| 文件 | 改动 |
|---|---|
| `SugarStatements.java` | if/elif/for/while 增加 `expressionMode`/`conditionExpr`，Expr 编辑器 UI、`expr "..."` 序列化格式、共享条件编辑器 helper |
| `SugarFunctions.java` | Expr 条件编译为 op 链 + 临时布尔变量；函数体重写同步处理条件表达式中的局部变量；`emitConditionExpression` + 临时变量重命名（`__ls_cond_*`）避免与用户变量冲突 |
| `SugarCompiler.java` | `invalidStatements` 对 Expr 条件做语法校验，失败标红 |
| `SugarCanvas.java` | 结构签名刷新覆盖 Expr 条件内容；缩进深度封顶 3 层防止行尾按钮被顶出屏幕；折叠按钮改为可见样式 |
| `BoxSelect.java` | 拖拽间距与布局 space 统一（拖动时分得更开、滚动条同步变长）；插入位置判定与视觉空隙同帧一致；布局切换后锚点补偿（blockend 不再偏移鼠标） |
| `ExpressionEditor.java` | 增加最小宽度，保证可点击 |
| `IfElseCompileTest.java` | Expr if/elif/for/while 编译 + 序列化往返测试用例 |

## 序列化格式

```text
ifbegin expr "a > 5 && ready" 4
elif expr "fallback != 0"
forbegin i 0 1 expr "i < count && go" 2
whilebegin expr "x < 10 && ready" 2
```

普通三段式格式完全兼容，不破坏已有存档。

## 测试

```text
Neon compileJava: BUILD SUCCESSFUL
IfElseCompileTest: ALL CHECKS PASSED
```