### PR TITLE
ci: add pull request checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,60 @@
+name: LogicSugar PR checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: logic-sugar-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out LogicSugar
+        uses: actions/checkout@v4
+        with:
+          path: LogicSugar
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Check out Mindustry v155.4
+        uses: actions/checkout@v4
+        with:
+          repository: Anuken/Mindustry
+          ref: 6c53474479fc9e11c66621bc953a800d816f3ff8
+          path: Mindustry-master
+          fetch-depth: 1
+
+      - name: Check out the matching Arc revision
+        uses: actions/checkout@v4
+        with:
+          repository: Anuken/Arc
+          ref: 7637600c41922c078ac6bde26953ef1e71746f35
+          path: Arc
+          fetch-depth: 1
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Mindustry desktop dependency
+        working-directory: Mindustry-master
+        run: ./gradlew --no-daemon desktop:dist
+
+      - name: Verify Mindustry dependency JAR
+        run: test -s Mindustry-master/desktop/build/libs/Mindustry.jar
+
+      - name: Compile and run LogicSugar checks
+        working-directory: LogicSugar
+        run: ./gradlew --no-daemon check --stacktrace --console=plain


### PR DESCRIPTION
## Summary
- build the pinned Mindustry v155.4 desktop dependency
- compile LogicSugar and run the existing self-tests on pull requests
- run checks again on pushes to main

The workflow intentionally runs `check` instead of `build/deploy`, so PR validation does not require Android SDK/D8.
