### PR TITLE
fix(cards): 语句块确定性换行 + For 固定两行 + 下划线配色修复

### DIFF
--- a/src/logicsugar/assist/BoxSelect.java
+++ b/src/logicsugar/assist/BoxSelect.java
@@ -127,8 +127,8 @@ public class BoxSelect{
     private static void setDragLayoutSpace(LCanvas canvas, float space){
         try{
             dragLayoutSpaceField.setFloat(canvas.statements, space);
-            // 同步折叠隐藏语句的 space 抵消值，保证 layout() 里 getPrefHeight()+space=0 始终成立
-            SugarCanvas.SugarStatementElem.foldHiddenSpace = -space;
+            // 同步所有折叠隐藏语句的 space 抵消值，保证 layout() 里 getPrefHeight()+space=0 始终成立
+            SugarCanvas.syncFoldHiddenSpace(canvas, space);
             // 高度变化需要双重 invalidate+validate（参考 finalizeLayout）：
             // 第一次 layout 用旧 height 执行并标记父节点，第二次用新 height 真正重排。
             canvas.statements.invalidate();

--- a/src/mindustry/logic/SugarCanvas.java
+++ b/src/mindustry/logic/SugarCanvas.java
@@ -233,6 +233,19 @@ public class SugarCanvas extends LCanvas{
         return compactCards() ? 0f : Scl.scl(vanillaSpace);
     }
 
+    /** Re-applies the fold-height compensation to every statement in the active Sugar canvas.
+     *  The value is per element rather than static so separate canvas instances cannot overwrite
+     *  one another's layout state. */
+    public static void syncFoldHiddenSpace(LCanvas canvas, float space){
+        if(!(canvas instanceof SugarCanvas sugar) || sugar.statements == null) return;
+        float compensation = -space;
+        for(Element child : sugar.statements.getChildren()){
+            if(child instanceof SugarStatementElem elem){
+                elem.foldHiddenSpace = compensation;
+            }
+        }
+    }
+
     private void setLayoutSpace(){
         if(statements == null || spaceField == null) return;
         try{
@@ -240,9 +253,8 @@ public class SugarCanvas extends LCanvas{
             // the vanilla 10-unit spacing so cards read as separate blocks.
             float space = currentIdleSpace();
             spaceField.setFloat(statements, space);
-            // 让折叠隐藏语句的布局贡献与当前 space 匹配：折叠 body 返回 -space 抵消 space，
-            // 则 getPrefHeight()+space=0，折叠块内部不再撑出空隙。
-            SugarStatementElem.foldHiddenSpace = -space;
+            // 让每个折叠隐藏元素使用与当前 DragLayout 相同的 space 抵消值。
+            syncFoldHiddenSpace(this, space);
         }catch(IllegalAccessException exception){
             throw new RuntimeException("Unable to configure Logic Sugar layout", exception);
         }
@@ -419,14 +431,11 @@ public class SugarCanvas extends LCanvas{
         boolean foldedHidden;
         boolean structureInvalid;
         float inset;
-        /** 折叠隐藏时用于抵消布局 space 的负值缓存。layout() 用 getPrefHeight()+space 累计高度，
-         *  折叠 body 隐藏后若仍贡献 space，会在 Begin 与 end 之间撑出空隙（非紧凑模式下尤其明显，
-         *  且该空隙可被框选命中）。此字段保存 -space，使折叠 body 贡献 getPrefHeight()+space=0。
-         *  public，便于 BoxSelect 在拖动切换 space 时同步。 */
-        public static float foldHiddenSpace = 0f;
+        float foldHiddenSpace;
 
         SugarStatementElem(LStatement statement){
             super(statement);
+            foldHiddenSpace = -currentIdleSpace();
             background(new InsetDrawable(this, Tex.whitePane));
             update(this::refreshInset);
             if(statement instanceof BlockEndStatement && getCells().size > 1){
@@ -486,10 +495,9 @@ public class SugarCanvas extends LCanvas{
             // marginLeft() applies Scl.scl() itself, so inset must stay in design units here;
             // pre-scaling it would double-scale (visible at 200% UI scale).
             float unit = Core.graphics.isPortrait() ? 17f : 24f;
-            // The condition row uses two 85px fields, a 48px operator button and their padding.
-            // Keep enough room for that row plus the card's own padding, then derive the maximum
-            // inset from the actual card width instead of stopping at an arbitrary depth.
-            float minContentWidth = 260f;
+            // Keep enough room for the condition row and the trailing mode/fold controls even
+            // in deeply nested cards; the inset must not consume that control area.
+            float minContentWidth = 360f;
             float designWidth = getWidth() / Scl.scl(1f);
             float maxInset = Math.max(0f, designWidth - minContentWidth);
             float depthInset = Math.max(0, structureDepth) * unit;

--- a/src/mindustry/logic/SugarStatements.java
+++ b/src/mindustry/logic/SugarStatements.java
@@ -81,7 +81,7 @@ public final class SugarStatements{
             return LCategory.control;
         }
 
-        /** {@link JumpStatement#addOp} with the value/compare fields narrowed to 85px, so
+        /** {@link JumpStatement#addOp} with the value/compare fields narrowed to 75px, so
          *  condition rows remain usable after structure indentation is applied.
          *
          *  Must be an instance method on this subclass: {@code field} and {@code showSelect}
@@ -90,7 +90,7 @@ public final class SugarStatements{
          *  helper throws IllegalAccessError (see AGENTS.md). Subclass access stays legal. */
         public void addCompactOp(Table t, ConditionOp op, Cons<ConditionOp> setOp,
                                  String value, Cons<String> setValue, String compare, Cons<String> setCompare){
-            if(op != ConditionOp.always) field(t, value, setValue).width(85f).pad(2f);
+            if(op != ConditionOp.always) field(t, value, setValue).width(75f).pad(2f);
 
             t.button(b -> {
                 b.add(op.symbol);
@@ -98,7 +98,7 @@ public final class SugarStatements{
             }, Styles.logict, () -> {
             }).size(op == ConditionOp.always ? 80f : 48f, 40f).pad(4f).color(t.color);
 
-            if(op != ConditionOp.always) field(t, compare, setCompare).width(85f).pad(2f);
+            if(op != ConditionOp.always) field(t, compare, setCompare).width(75f).pad(2f);
         }
 
         /** Attaches a vanilla-style hover hint to a parameter label (bundle key: logicsugar.hint.<key>). */
@@ -106,22 +106,36 @@ public final class SugarStatements{
             LCanvas.tooltip(cell, "logicsugar.hint." + key);
         }
 
-        /** Label + input row with a hover hint on the label, like vanilla fields(). */
+        /** Label + input grouped into one nested cell, preventing sibling fields from expanding
+         *  each other's columns in the compact For layout. */
         protected Cell<TextField> fieldsHint(Table table, String desc, String hintKey, String value, Cons<String> setter){
-            table.add(desc).padLeft(10).left().self(c -> hint(c, hintKey));
-            return field(table, value, setter).width(85f).padRight(10).left();
-        }
-
-        /** Ends the current layout row even when the canvas is using the wide form. */
-        protected void rowAlways(Table table){
-            table.row();
+            Cell<TextField>[] result = new Cell[]{null};
+            table.table(inner -> {
+                inner.left();
+                Color target = elem == null ? Pal.logicControl : elem.color;
+                inner.setColor(target);
+                inner.add(desc).padLeft(10).left().self(c -> hint(c, hintKey));
+                // 输入框略收窄(85→65)，使窄屏下三个"标签+输入框"组连同右侧条件不超出卡片；
+                // 同时收紧组间 padRight(10→6)。仅作用于 For 前置区，不影响其他语句。
+                result[0] = field(inner, value, setter).width(65f).padRight(6).left();
+                TextField input = result[0].get();
+                input.setColor(target);
+                // 跟随语句卡片状态（正常蓝色/无效红色），不能依赖父 Table 的初始化颜色：
+                // table.table(Cons) 回调执行时外层 Cell.color 还没应用，table.color 仍可能是白色。
+                inner.update(() -> {
+                    Color current = elem == null ? Pal.logicControl : elem.color;
+                    inner.setColor(current);
+                    input.setColor(current);
+                });
+            }).left();
+            return result[0];
         }
     }
 
     /**
      * Shared condition editor for if/elif/for/while: the native three-part selector and the
-     * EXPR/OP mode toggle are placed on separate rows. The row colour follows the statement
-     * card every frame, so invalid-state red marking can never leave a stale snapshot behind.
+     * EXPR/OP mode toggle stay on the same row. The row colour follows the statement card
+     * every frame, so invalid-state red marking can never leave a stale snapshot behind.
      *
      * @param compactCondition uses narrower condition fields (85px like the vanilla
      *                         {@code fields} helper instead of the 144px ones vanilla
@@ -145,11 +159,8 @@ public final class SugarStatements{
         });
         if(expressionMode){
             table.add(new ExpressionEditor(expr, text("condition.expr.hint", "a > b && enabled"), setExpr))
-                .colspan(3).growX().fillX().pad(4f);
-            // Keep the mode button on a separate row so a long expression never pushes it out.
-            table.row();
-            table.add().growX();
-            table.add().growX();
+                .growX().fillX().pad(4f);
+            // 显示当前状态：Expr 模式下按钮显示 "Expr"，点击切回三段式
             table.button(b -> {
                 b.add(text("condition.expr", "Expr"));
                 b.clicked(() -> {
@@ -169,12 +180,7 @@ public final class SugarStatements{
                     rebuild.run();
                 }, value, setValue, compare, setCompare);
             }
-
-            // The selector row is deliberately independent from the mode toggle row. This is
-            // also used on the wide canvas because nested statement cards have less width.
-            table.row();
-            table.add().growX();
-            table.add().growX();
+            // 条件三段式与 op 切换按钮始终保持在同一行；语句块层只负责 For 的固定分组换行。
             table.button(b -> {
                 b.add(text("condition.expr.back", "op"));
                 b.clicked(() -> {
@@ -184,10 +190,6 @@ public final class SugarStatements{
             }, Styles.logict, () -> {}).size(48f, 40f).pad(4f).color(table.color);
         }
     }
-
-    /** {@link JumpStatement#addOp} with the value/compare fields narrowed to 85px lives on
-     *  {@link SugarStatement#addCompactOp}: it must run inside the subclass context, see the
-     *  classloader note there and in AGENTS.md. */
 
     public abstract static class BeginStatement extends SugarStatement{
         public transient StatementElem dest;
@@ -216,8 +218,6 @@ public final class SugarStatements{
 
         /** Places the fold action on its own row so it cannot be pushed outside the card. */
         protected void foldControlRow(Table table){
-            rowAlways(table);
-            table.add().growX();
             foldControl(table);
         }
 
@@ -296,17 +296,31 @@ public final class SugarStatements{
 
         @Override
         public void build(Table table){
+            // 先把前半行和后半行分成独立的子表格，避免条件控件的 growX 参与前面
+            // 字段列宽分配。宽屏合并为一行，窄屏只在步长后换一次行。
+            table.table(content -> {
+                content.left();
+                if(LCanvas.useRows()){
+                    content.table(this::buildForPrefix).left();
+                    content.row();
+                    content.table(this::buildForCondition).growX().fillX().left();
+                }else{
+                    buildForPrefix(content);
+                    buildForCondition(content);
+                }
+            }).growX().fillX().left();
+        }
+
+        private void buildForPrefix(Table table){
             fieldsHint(table, text("for.variable", "variable"), "for.variable", variable, value -> variable = value);
-            rowAlways(table);
             fieldsHint(table, text("for.initial", "initial"), "for.initial", initial, value -> initial = value);
-            rowAlways(table);
             fieldsHint(table, text("for.step", "step"), "for.step", step, value -> step = value);
-            rowAlways(table);
-            // 终止条件：描述 + 三段式（value op compare）或 Expr
+        }
+
+        private void buildForCondition(Table table){
             table.add(text("for.condition", "until")).padLeft(10).left().self(c -> hint(c, "for.condition"));
-            rowAlways(table);
-            table.table(this::rebuildCondition).colspan(2).growX().fillX();
-            foldControlRow(table);
+            table.table(this::rebuildCondition).growX().fillX().left();
+            foldControl(table);
         }
 
         private void rebuildCondition(Table table){
@@ -349,8 +363,7 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("condition", "condition")).self(c -> hint(c, "while.condition"));
-            rowAlways(table);
-            table.table(this::rebuildCondition).colspan(2).growX().fillX();
+            table.table(this::rebuildCondition).growX().fillX();
             foldControlRow(table);
         }
 
@@ -385,7 +398,6 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("switch.value", "switch")).self(c -> hint(c, "switch.value"));
-            rowAlways(table);
             field(table, value, result -> value = result).width(85f);
             foldControlRow(table);
         }
@@ -418,8 +430,7 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("if.condition", "if")).self(c -> hint(c, "if.condition"));
-            rowAlways(table);
-            table.table(this::rebuildCondition).colspan(2).growX().fillX();
+            table.table(this::rebuildCondition).growX().fillX();
             foldControlRow(table);
         }
 
@@ -460,8 +471,7 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("elif", "elif")).self(c -> hint(c, "elif"));
-            rowAlways(table);
-            table.table(this::rebuildCondition).colspan(2).growX().fillX();
+            table.table(this::rebuildCondition).growX().fillX();
         }
 
         private void rebuildCondition(Table table){
@@ -502,7 +512,6 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("func.def", "func")).self(c -> hint(c, "func.def"));
-            rowAlways(table);
             field(table, name, value -> name = value).width(90f);
             table.add("(");
             TextField paramsField = field(table, params, value -> params = value).width(130f).get();
@@ -530,17 +539,14 @@ public final class SugarStatements{
         @Override
         public void build(Table table){
             table.add(text("func.call", "call")).self(c -> hint(c, "func.call"));
-            rowAlways(table);
             field(table, name, value -> name = value).width(90f);
-            rowAlways(table);
             table.add("(");
             // 实参：完整表达式，高亮显示，点击进入编辑；
             // 空值时提示被调函数的参数列表（动态跟随函数名/参数变化），找不到或函数无参数时退回通用提示
             table.add(new ExpressionEditor(args, this::argsHint, value -> args = value))
                 .growX().padLeft(4f).padRight(2f);
             table.add(")");
-            rowAlways(table);
-            table.add("=").padLeft(10f);
+            table.add("=");
             field(table, result, value -> result = value).width(70f).padLeft(4f);
         }
 

--- a/src/mindustry/logic/SugarStatements.java
+++ b/src/mindustry/logic/SugarStatements.java
@@ -137,9 +137,8 @@ public final class SugarStatements{
      * EXPR/OP mode toggle stay on the same row. The row colour follows the statement card
      * every frame, so invalid-state red marking can never leave a stale snapshot behind.
      *
-     * @param compactCondition uses narrower condition fields (85px like the vanilla
-     *                         {@code fields} helper instead of the 144px ones vanilla
-     *                         {@code addOp} reserves).
+     * @param compactCondition uses narrower condition fields (75px instead of the
+     *                         144px ones vanilla {@code addOp} reserves).
      */
     private static void rebuildConditionEditor(LStatement owner, Table table, boolean expressionMode, String expr,
                                                Cons<String> setExpr, Runnable enterExpr, Runnable leaveExpr,
@@ -216,7 +215,8 @@ public final class SugarStatements{
             fold.update(() -> fold.getStyle().imageUp = collapsed ? mindustry.gen.Icon.rightOpen : mindustry.gen.Icon.downOpen);
         }
 
-        /** Places the fold action on its own row so it cannot be pushed outside the card. */
+        /** Adds the fold control at the end of the current row; row breaks are decided by
+         *  the statement layout (e.g. For's fixed two-row grouping). */
         protected void foldControlRow(Table table){
             foldControl(table);
         }


### PR DESCRIPTION
## 语句块确定性换行 + For 固定两行 + 下划线配色修复

### 背景

此前逻辑卡片在编辑器中存在两类问题：

1. **条件行换行不稳定** —— 早期实现（`responsiveRows`）尝试按实际宽度每帧动态判断是否换行，导致布局频繁重建、视觉跳动，且换来换去牺牲了卡片配色。
2. **For 语句列宽被撑开** —— For 的前缀字段（变量/初值/步长）与条件控件共用外层列宽，`growX` 会把列撑出大片空白。
3. **深缩进下条件行被挤出可视区** —— 缩进无限增长时，条件行后的模式/折叠按钮会被顶出屏幕。

### 改动

- **收回按总宽度动态重建**：删除 `responsiveRows` / `responsiveLayout` 及多余的 `row()`。`While/If/ElseIf/Switch/FuncDef/FuncCall/Return` 不再自动换行，回归确定性单行布局。
- **For 固定两行**：宽屏合并为一行；窄屏（`LCanvas.useRows()`）只在步长后固定换一次行。前缀与条件拆成独立子表，避免条件控件 `growX` 参与前缀列宽分配。
- **条件编辑器**：op/expr 切换按钮与三段式条件保持同一行；恢复 PR 配色（`table.setColor` + 每帧 `child.setColor`），修复下划线变白。
- **fieldsHint**：标签 + 输入框收进嵌套 cell，按内容紧凑排列，避免兄弟字段互相撑列宽；每帧同步 TextField 颜色，修复变量/初值/步长下划线变白。
- **缩进上限按卡片宽度推导**：`minContentWidth` 260→360f，为条件行 + 行尾模式/折叠控制区保留空间，深嵌套时控制区不再被顶出。
- **折叠空间补偿按元素**：`foldHiddenSpace` 从静态全局改为按元素实例字段，新增 `syncFoldHiddenSpace` 统一切换入口，避免多画布互相污染；折叠块内部不再撑出空隙。
- **字段宽度收窄**：For 前置区输入框 85→65、条件行输入框 85→75、组间距 10→6，窄屏下条件行不超出卡片。

### 测试

- `./gradlew compileJava` → BUILD SUCCESSFUL
- 实测宽屏 / 窄屏（`useRows`）两种画布宽度下的 For / If / While / Switch / FuncDef / FuncCall / Return 布局。
- 实测深缩进（for→while→case）下条件行 + 行尾按钮可见性。
- 实测折叠块（compact / non-compact）下无残留空隙。
